### PR TITLE
Enable Debug fix Error like

### DIFF
--- a/servicelibpl/Makefile.am
+++ b/servicelibpl/Makefile.am
@@ -5,12 +5,9 @@ AM_CPPFLAGS = \
 	@PYTHON_CPPFLAGS@ \
 	-include Python.h
 
-AM_CPPFLAGS += \
-        -I$(top_srcdir)/../misc/tools/libeplayer3/include
 AM_CXXFLAGS = \
 	-Wall \
 	@ENIGMA2_CFLAGS@
-
 
 plugindir = $(libdir)/enigma2/python/Plugins/SystemPlugins/Servicelibpl
 

--- a/servicelibpl/servicelibpl.cpp
+++ b/servicelibpl/servicelibpl.cpp
@@ -1811,7 +1811,7 @@ void eServiceLibpl::gotThreadMessage(const int &msg)
 
 void libeplayerMessage(int message) // call from libeplayer
 {
-	// eDebug("[eServiceLibpl::%s] %d", __func__, message);
+	eDebug("[eServiceLibpl::%s] %d", __func__, message);
 	eServiceLibpl *serv = eServiceLibpl::getInstance();
 	serv->inst_m_pump->send(message);
 }


### PR DESCRIPTION
"eDVBPESReader] ERROR reading PES (fd=53): Value too large for defined data type
Backtrace:
/usr/bin/enigma2(_Z17handleFatalSignaliP9siginfo_tPv) [0x46A4C0]
/usr/lib/libavcodec.so.58(av_packet_copy_props) [0x2D13B976]"